### PR TITLE
Minor: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ This awesome list collects Open Source projects, web applications, interesting w
 
 ### 3D Printed Objects
 
-- [DPSG Lilie Cookie Cutter on Thingyverse](https://www.thingiverse.com/thing:4672759)
-- [Pfadi Stufe Cookie Cutter on Thingyverse](https://www.thingiverse.com/thing:4646424)
-- [Jupfi Stufe Cookie Cutter on Thingyverse](https://www.thingiverse.com/thing:4646408)
-- [Wölflings Stufe Cookie Cutter on Thingyverse](https://www.thingiverse.com/thing:4646398)
-- [Biber Stufe Cookie Cutter on Thingyverse](https://www.thingiverse.com/thing:4646427)
+- [DPSG Lilie Cookie Cutter on Thingiverse](https://www.thingiverse.com/thing:4672759)
+- [Pfadi Stufe Cookie Cutter on Thingiverse](https://www.thingiverse.com/thing:4646424)
+- [Jupfi Stufe Cookie Cutter on Thingiverse](https://www.thingiverse.com/thing:4646408)
+- [Wölflings Stufe Cookie Cutter on Thingiverse](https://www.thingiverse.com/thing:4646398)
+- [Biber Stufe Cookie Cutter on Thingiverse](https://www.thingiverse.com/thing:4646427)
 
 ---
 


### PR DESCRIPTION
Only fixing the typo "Thingyverse" -> "Thingiverse".
Not more or less value. 😉 
