### PR TITLE
Add NaMi EfZ Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This awesome list collects Open Source projects, web applications, interesting w
 - [NaMi Antragshelfer](https://github.com/tobiasmiosczka/nami-antragshelfer) - Programm zum Ausfüllen von Förderungsanträgen und Generieren von Notfall-Telefonlisten
 - [NaMi Beitragsrechner](https://github.com/f1shl/nami-beitragsrechner) - Automatische Erstellung von Lastschrifteinzügen aus der NaMi
 - [NaMi Mobile App](https://github.com/digital-scouts/dpsg-nami-app) - `Work in Progress` Mobile App for NaMi built with Flutter
+- [NaMi EfZ Check](https://github.com/maehw/nami-efz-check) - Automate check of SGB VIII-Bescheinigung by its Identifikationsnummer (Erweitertes Führzungszeugnis, EfZ) by querying the NaMi web server
 
 ## Design and Themes
 


### PR DESCRIPTION
Ich füge hiermit [NaMi EfZ Check](https://github.com/maehw/nami-efz-check) hinzu.
Es kann Arbeit im Stamm (oder ggf. auch auf der Bezirks- oder Diözesanebene) untersützen. Man kann die Gültigkeit von EfZ-Bescheinigungen automatisiert für die Mitglieder prüfen bzw. für Teilnehmende an Veranstaltungen. Möglicherweise ist dies sowieso in der jeweiligen Gruppierung schon durch ein Institutionelles Schutzkonzept (ISK) vorgesehen (bzw. wird es bald sein). Das Skript soll als Tool, den manuellen Aufwand bei der Überprüfung reduzieren.

Not really in English, but the README.md in the repo will explain it there. And DPSG members usually are German speaking.

> **Disclaimer**
> I made the tool, so this is a [shameless plug](https://www.urbandictionary.com/define.php?term=Shameless%20Plug).
