### PR TITLE
add nami mockserver to helper tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This awesome list collects Open Source projects, web applications, interesting w
 - [NaMi Antragshelfer](https://github.com/tobiasmiosczka/nami-antragshelfer) - Programm zum Ausfüllen von Förderungsanträgen und Generieren von Notfall-Telefonlisten
 - [NaMi Beitragsrechner](https://github.com/f1shl/nami-beitragsrechner) - Automatische Erstellung von Lastschrifteinzügen aus der NaMi
 - [NaMi Mobile App](https://github.com/digital-scouts/dpsg-nami-app) - `Work in Progress` Mobile App for NaMi built with Flutter
+- [NaMi Mockserver](https://github.com/digital-scouts/nami-mockserver) - Provides a few endpoints to test own application
 - [NaMi EfZ Check](https://github.com/maehw/nami-efz-check) - Automate check of SGB VIII-Bescheinigung by its Identifikationsnummer (Erweitertes Führzungszeugnis, EfZ) by querying the NaMi web server
 - [NaMi cli](https://github.com/webratz/pynami) - `alpha state` Cli to interact with NaMi API
 - [Nami doku](https://doku.dpsg.de/spacedirectory/view.action) - Nami Dokumentation


### PR DESCRIPTION
Ich füge hiermit das Repository Name-Mockserver hinzu. Damit ist es möglich seine Anwendung mit Daten zu testen ohne direkt gegen den Live Server zu gehen.
