### PR TITLE
Add iscout-task-dispatch to Self Hosted Web Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This awesome list collects Open Source projects, web applications, interesting w
 - [Seatsurfing](https://seatsurfing.app/) - Webbased app to book seats, desks and rooms for offices. Can be used for Gruppenraum ([Demo](https://seatsurfing.app/get-started/), [Source Code](https://github.com/seatsurfing/backend)) `GPL-3.0` `Docker`
 - [knotnpunkt](https://github.com/dpsg-beckum/knotnpunkt) - `Work in progress` Material management for scout groups
 - [Adrema](https://github.com/zoomyboy/adrema) - Management for group members and frontend for NaMi
+- [iscout-task-dispatch](https://github.com/dpsg-beckum/iscout-task-dispatch) - `Work in progress` Basic Task Managment for the game [iScout](https://iscoutgame.com). ([Demo](https://itd-test.remote1.jonahwille.de))
 
 ## NaMi Helper Tools
 


### PR DESCRIPTION
iscout-task-dispatch (kurz itd) ist ein einfaches Tool um die Aufgaben von [iScout](iscoutgame.com) zu Verwalten.  Aufgaben können hierbei selbständig von den Teams Bearbeitet werden. Durch die Verwendung des Tools wird ein doppeltes Bearbeiten der Aufgaben verhindert. 

Itd ist weiterhin in der Entwicklung, eine Testinstallation mit den Aufgaben aus 2024 läuft unter https://itd-test.remote1.jonahwille.de 

Leider wird dieses Jahr iScout zum letzten mal veranstaltet. Aber vielleicht kommt es ja noch einmal wieder.